### PR TITLE
Adapt to the latest version of cupy

### DIFF
--- a/interpolate_video_gmfss_union_anyfps.py
+++ b/interpolate_video_gmfss_union_anyfps.py
@@ -274,7 +274,7 @@ def calc_t(_idx):
 mt, zt, pt = calc_t(idx)
 right_scene = scene_detection.check_scene(i0, i1)
 left_scene = right_scene
-output = make_inference(I0, I0, I1, mt, zt, pt, scale, False, right_scene, scale)
+output = make_inference(I0, I0, I1, mt, zt, pt, False, right_scene, scale)
 for x in output:
     put(x)
 pbar.update(1)

--- a/models/model_nb222/softsplat.py
+++ b/models/model_nb222/softsplat.py
@@ -222,7 +222,7 @@ def cuda_launch(strKey:str):
         os.environ['CUDA_HOME'] = cupy.cuda.get_cuda_path()
     # end
 
-    return cupy.cuda.compile_with_cache(objCudacache[strKey]['strKernel'], tuple(['-I ' + os.environ['CUDA_HOME'], '-I ' + os.environ['CUDA_HOME'] + '/include'])).get_function(objCudacache[strKey]['strFunction'])
+    return cupy.RawModule(code=objCudacache[strKey]['strKernel'], options=('-I ' + os.environ.get('CUDA_HOME'), '-I ' + os.environ.get('CUDA_HOME') + '/include')).get_function(objCudacache[strKey]['strFunction'])
 # end
 
 

--- a/models/model_pg104/softsplat.py
+++ b/models/model_pg104/softsplat.py
@@ -222,7 +222,7 @@ def cuda_launch(strKey:str):
         os.environ['CUDA_HOME'] = cupy.cuda.get_cuda_path()
     # end
 
-    return cupy.cuda.compile_with_cache(objCudacache[strKey]['strKernel'], tuple(['-I ' + os.environ['CUDA_HOME'], '-I ' + os.environ['CUDA_HOME'] + '/include'])).get_function(objCudacache[strKey]['strFunction'])
+    return cupy.RawModule(code=objCudacache[strKey]['strKernel'], options=('-I ' + os.environ.get('CUDA_HOME'), '-I ' + os.environ.get('CUDA_HOME') + '/include')).get_function(objCudacache[strKey]['strFunction'])
 # end
 
 


### PR DESCRIPTION
According to https://docs.cupy.dev/en/stable/upgrade.html#api-changes, cupy.cuda.compile_with_cache() has been deleted in the latest version and needs to be replaced by other APIs

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Adapt the codebase to the latest version of CuPy by replacing the deprecated compile_with_cache() function with RawModule() in the softsplat.py files and adjust the make_inference function call in interpolate_video_gmfss_union_anyfps.py.

Enhancements:
- Replace deprecated cupy.cuda.compile_with_cache() with cupy.RawModule() in softsplat.py files to adapt to the latest version of CuPy.

<!-- Generated by sourcery-ai[bot]: end summary -->